### PR TITLE
Customize font size, font family, and background

### DIFF
--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -7,7 +7,7 @@
    ========================================================================== */
 
 /* Used to set the size for <em> */
-$doc-font-size              : 16;
+$doc-font-size              : 14;
 
 /* Paragraph indention */
 $paragraph-indent           : false; // true, false (default)
@@ -39,8 +39,8 @@ $type-size-6                : 0.75em;   // ~12px
 $type-size-7                : 0.6875em; // ~11px
 $type-size-8                : 0.625em;  // ~10px
 
-$global-font-family         : $sans-serif;
-$header-font-family         : $sans-serif;
+$global-font-family         : Arial, sans-serif;
+$header-font-family         : Arial, sans-serif;
 $caption-font-family        : $serif;
 
 /* ==========================================================================

--- a/_sass/theme/_default.scss
+++ b/_sass/theme/_default.scss
@@ -29,7 +29,7 @@ $sidebar-screen-min-width   : 1024px;
 /* Default light theme for the site */
 :root {
     --global-base-color                 : #{$gray};
-    --global-bg-color                   : #fff;
+    --global-bg-color                   : #f0f0f0;
     --global-footer-bg-color            : #f2f3f3;
     --global-border-color               : #{$lighter-gray};
     --global-dark-border-color          : #bdc1c4;


### PR DESCRIPTION
## Summary
- Reduce base font size to 14 for smaller default text
- Switch global and header fonts to Arial
- Change global background color to light grey

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_689209bba8e4832292b33fd8a82780c1